### PR TITLE
Fixed small mypy issue when working with application_id

### DIFF
--- a/backend/moonstream/routes/subscriptions.py
+++ b/backend/moonstream/routes/subscriptions.py
@@ -99,7 +99,6 @@ async def add_subscription_handler(
     resource_data.update(subscription_data)
 
     try:
-
         resource: BugoutResource = bc.create_resource(
             token=token,
             application_id=MOONSTREAM_APPLICATION_ID,

--- a/backend/moonstream/settings.py
+++ b/backend/moonstream/settings.py
@@ -5,8 +5,9 @@ from bugout.app import Bugout
 # Bugout
 bugout_client = Bugout()
 
-MOONSTREAM_APPLICATION_ID = os.environ.get("MOONSTREAM_APPLICATION_ID")
-if MOONSTREAM_APPLICATION_ID is None:
+# Default value is "" instead of None so that mypy understands that MOONSTREAM_APPLICATION_ID is a string
+MOONSTREAM_APPLICATION_ID = os.environ.get("MOONSTREAM_APPLICATION_ID", "")
+if MOONSTREAM_APPLICATION_ID == "":
     raise ValueError("MOONSTREAM_APPLICATION_ID environment variable must be set")
 
 MOONSTREAM_DATA_JOURNAL_ID = os.environ.get("MOONSTREAM_DATA_JOURNAL_ID")


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Fixes mypy error where mypy couldn't understand that `MOONSTREAM_APPLICATION_ID` was not `Optional[str]` but rather a `str`.
<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

From `backend/` with virtualenv activated:
```
mypy moonstream/
```

Should exit 0
<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
