### PR TITLE
Crawlers ethcrawler sync

### DIFF
--- a/crawlers/moonstreamcrawlers/cli.py
+++ b/crawlers/moonstreamcrawlers/cli.py
@@ -54,11 +54,12 @@ def ethcrawler_blocks_sync_handler(args: argparse.Namespace) -> None:
     """
     Synchronize latest Ethereum blocks with database.
     """
+    starting_block: int = args.start
     while True:
         bottom_block_number, top_block_number = get_latest_blocks(
             bool(strtobool(args.transactions))
         )
-        bottom_block_number = bottom_block_number + 1
+        bottom_block_number = max(bottom_block_number + 1, starting_block)
         if bottom_block_number >= top_block_number:
             print(
                 f"Synchronization is unnecessary for blocks {bottom_block_number}-{top_block_number - 1}"
@@ -177,6 +178,13 @@ def main() -> None:
         choices=["True", "False"],
         default="True",
         help="Add or not block transactions",
+    )
+    parser_ethcrawler_blocks_sync.add_argument(
+        "-s",
+        "--start",
+        type=int,
+        default=0,
+        help="(Optional) Block to start synchronization from. Default: 0",
     )
     parser_ethcrawler_blocks_sync.set_defaults(func=ethcrawler_blocks_sync_handler)
 

--- a/crawlers/moonstreamcrawlers/ethereum.py
+++ b/crawlers/moonstreamcrawlers/ethereum.py
@@ -71,16 +71,21 @@ def add_block_transactions(db_session, block: BlockData) -> None:
         db_session.add(tx_obj)
 
 
-def get_latest_blocks(with_transactions: bool = False) -> None:
+def get_latest_blocks(with_transactions: bool = False) -> Tuple[Optional[int], int]:
     web3_client = connect()
     block_latest: BlockData = web3_client.eth.get_block(
         "latest", full_transactions=with_transactions
     )
     with yield_db_session_ctx() as db_session:
-        block_number_latest_exist = (
+        block_number_latest_exist_row = (
             db_session.query(EthereumBlock.block_number)
             .order_by(EthereumBlock.block_number.desc())
             .first()
+        )
+        block_number_latest_exist = (
+            None
+            if block_number_latest_exist_row is None
+            else block_number_latest_exist_row[0]
         )
 
     return block_number_latest_exist, block_latest.number

--- a/crawlers/moonstreamcrawlers/ethereum.py
+++ b/crawlers/moonstreamcrawlers/ethereum.py
@@ -1,8 +1,8 @@
 from concurrent.futures import Future, ProcessPoolExecutor, wait
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 from sqlalchemy import desc
-from web3 import Web3
+from web3 import Web3, IPCProvider, HTTPProvider
 from web3.types import BlockData
 
 from .settings import MOONSTREAM_IPC_PATH, MOONSTREAM_CRAWL_WORKERS
@@ -14,9 +14,14 @@ from moonstreamdb.models import (
 )
 
 
-# TODO(kompotkot): Write logic to chose between http and ipc
-def connect(ipc_path: str = MOONSTREAM_IPC_PATH):
-    web3_client = Web3(Web3.IPCProvider(ipc_path))
+def connect(web3_uri: Optional[str] = MOONSTREAM_IPC_PATH):
+    web3_provider: Union[IPCProvider, HTTPProvider] = Web3.IPCProvider()
+    if web3_uri is not None:
+        if web3_uri.startswith("http://") or web3_uri.startswith("https://"):
+            web3_provider = Web3.HTTPProvider(web3_uri)
+        else:
+            web3_provider = Web3.IPCProvider(web3_uri)
+    web3_client = Web3(web3_provider)
     return web3_client
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Adds a `--start` argument to `blocks synchronize`. This allows us to start constant synchronization with the latest state of the blockchain from a given starting block.

Also adds support for HTTP providers for the Web3 connection.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

Run them locally.

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

Resolves https://github.com/bugout-dev/moonstream/issues/36

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
