### PR TITLE
Added "--order" and "--jobs" arguments to "ethcrawler blocks synchronize"

### DIFF
--- a/crawlers/moonstreamcrawlers/cli.py
+++ b/crawlers/moonstreamcrawlers/cli.py
@@ -222,8 +222,8 @@ def main() -> None:
     parser_ethcrawler_blocks_sync.add_argument(
         "--order",
         type=processing_order,
-        choices=valid_processing_orders,
-        help="Order in which to process blocks",
+        default=ProcessingOrder.DESCENDING,
+        help="Order in which to process blocks (choices: desc, asc; default: desc)",
     )
     parser_ethcrawler_blocks_sync.set_defaults(func=ethcrawler_blocks_sync_handler)
 

--- a/crawlers/moonstreamcrawlers/cli.py
+++ b/crawlers/moonstreamcrawlers/cli.py
@@ -3,9 +3,11 @@ Moonstream crawlers CLI.
 """
 import argparse
 from distutils.util import strtobool
+from enum import Enum
 import json
 import sys
 import time
+from typing import Iterator, List
 
 from .ethereum import (
     crawl_blocks_executor,
@@ -17,37 +19,62 @@ from .ethereum import (
 from .settings import MOONSTREAM_CRAWL_WORKERS
 
 
-def yield_blocks_numbers_lists(blocks_range_str: str) -> None:
+class ProcessingOrder(Enum):
+    DESCENDING = 0
+    ASCENDING = 1
+
+
+def yield_blocks_numbers_lists(
+    blocks_range_str: str,
+    order: ProcessingOrder = ProcessingOrder.DESCENDING,
+    block_step: int = 1000,
+) -> Iterator[List[int]]:
     """
     Generate list of blocks.
     Block steps used to prevent long executor tasks and data loss possibility.
     """
-    block_step = 1000
-
     try:
         blocks_start_end = blocks_range_str.split("-")
-        bottom_block_number = int(blocks_start_end[0])
-        top_block_number = int(blocks_start_end[1])
-        required_blocks_len = top_block_number - bottom_block_number + 1
+        input_start_block = int(blocks_start_end[0])
+        input_end_block = int(blocks_start_end[1])
     except Exception:
         print(
             "Wrong format provided, expected {bottom_block}-{top_block}, as ex. 105-340"
         )
         return
 
-    print(f"Required {required_blocks_len} blocks to process")
+    starting_block = max(input_start_block, input_end_block)
+    ending_block = min(input_start_block, input_end_block)
 
-    while not top_block_number < bottom_block_number:
-        temp_bottom_block_number = top_block_number - block_step
-        if temp_bottom_block_number < bottom_block_number:
-            temp_bottom_block_number = bottom_block_number - 1
-        blocks_numbers_list = list(
-            range(top_block_number, temp_bottom_block_number, -1)
-        )
+    stepsize = -1
+    if order == ProcessingOrder.ASCENDING:
+        starting_block = min(input_start_block, input_end_block)
+        ending_block = max(input_start_block, input_end_block)
+        stepsize = 1
+
+    current_block = starting_block
+
+    def keep_going() -> bool:
+        if order == ProcessingOrder.ASCENDING:
+            return current_block <= ending_block
+        return current_block >= ending_block
+
+    while keep_going():
+        temp_ending_block = current_block + stepsize * block_step
+        if order == ProcessingOrder.ASCENDING:
+            if temp_ending_block > ending_block:
+                temp_ending_block = ending_block + 1
+        else:
+            if temp_ending_block < ending_block:
+                temp_ending_block = ending_block - 1
+        blocks_numbers_list = list(range(current_block, temp_ending_block, stepsize))
 
         yield blocks_numbers_list
 
-        top_block_number -= block_step
+        if order == ProcessingOrder.ASCENDING:
+            current_block += block_step
+        else:
+            current_block -= block_step
 
 
 def ethcrawler_blocks_sync_handler(args: argparse.Namespace) -> None:
@@ -169,6 +196,18 @@ def main() -> None:
         description="Ethereum blocks commands"
     )
 
+    valid_processing_orders = {
+        "asc": ProcessingOrder.ASCENDING,
+        "desc": ProcessingOrder.DESCENDING,
+    }
+
+    def processing_order(raw_order: str) -> ProcessingOrder:
+        if raw_order in valid_processing_orders:
+            return valid_processing_orders[raw_order]
+        raise ValueError(
+            f"Invalid processing order ({raw_order}). Valid choices: {valid_processing_orders.keys()}"
+        )
+
     parser_ethcrawler_blocks_sync = subcommands_ethcrawler_blocks.add_parser(
         "synchronize", description="Synchronize to latest ethereum block commands"
     )
@@ -185,6 +224,12 @@ def main() -> None:
         type=int,
         default=0,
         help="(Optional) Block to start synchronization from. Default: 0",
+    )
+    parser_ethcrawler_blocks_sync.add_argument(
+        "--order",
+        type=processing_order,
+        choices=valid_processing_orders,
+        help="Order in which to process blocks",
     )
     parser_ethcrawler_blocks_sync.set_defaults(func=ethcrawler_blocks_sync_handler)
 

--- a/crawlers/moonstreamcrawlers/cli.py
+++ b/crawlers/moonstreamcrawlers/cli.py
@@ -105,9 +105,7 @@ def ethcrawler_blocks_sync_handler(args: argparse.Namespace) -> None:
                 with_transactions=bool(strtobool(args.transactions)),
                 num_processes=args.jobs,
             )
-
         print(f"Synchronized blocks from {bottom_block_number} to {top_block_number}")
-        time.sleep(5)
 
 
 def ethcrawler_blocks_add_handler(args: argparse.Namespace) -> None:

--- a/crawlers/moonstreamcrawlers/cli.py
+++ b/crawlers/moonstreamcrawlers/cli.py
@@ -93,24 +93,18 @@ def ethcrawler_blocks_sync_handler(args: argparse.Namespace) -> None:
             )
             time.sleep(20)
             continue
-        if top_block_number - bottom_block_number >= 10:
-            for blocks_numbers_list in yield_blocks_numbers_lists(
-                f"{bottom_block_number}-{top_block_number}"
-            ):
-                print(
-                    f"Adding blocks {blocks_numbers_list[-1]}-{blocks_numbers_list[0]}"
-                )
-                crawl_blocks_executor(
-                    block_numbers_list=blocks_numbers_list,
-                    with_transactions=bool(strtobool(args.transactions)),
-                )
-        else:
-            blocks_numbers_list = range(bottom_block_number, top_block_number + 1)
-            print(f"Adding blocks {bottom_block_number}-{top_block_number - 1}")
-            crawl_blocks(
-                blocks_numbers=blocks_numbers_list,
+
+        for blocks_numbers_list in yield_blocks_numbers_lists(
+            f"{bottom_block_number}-{top_block_number}",
+            order=args.order,
+        ):
+            print(f"Adding blocks {blocks_numbers_list[-1]}-{blocks_numbers_list[0]}")
+            # TODO(kompotkot): Set num_processes argument based on number of blocks to synchronize.
+            crawl_blocks_executor(
+                block_numbers_list=blocks_numbers_list,
                 with_transactions=bool(strtobool(args.transactions)),
             )
+
         print(f"Synchronized blocks from {bottom_block_number} to {top_block_number}")
         time.sleep(10)
 

--- a/crawlers/moonstreamcrawlers/cli.py
+++ b/crawlers/moonstreamcrawlers/cli.py
@@ -91,7 +91,7 @@ def ethcrawler_blocks_sync_handler(args: argparse.Namespace) -> None:
             print(
                 f"Synchronization is unnecessary for blocks {bottom_block_number}-{top_block_number - 1}"
             )
-            time.sleep(20)
+            time.sleep(5)
             continue
 
         for blocks_numbers_list in yield_blocks_numbers_lists(
@@ -107,7 +107,7 @@ def ethcrawler_blocks_sync_handler(args: argparse.Namespace) -> None:
             )
 
         print(f"Synchronized blocks from {bottom_block_number} to {top_block_number}")
-        time.sleep(10)
+        time.sleep(5)
 
 
 def ethcrawler_blocks_add_handler(args: argparse.Namespace) -> None:
@@ -234,7 +234,7 @@ def main() -> None:
         help=(
             f"Number of processes to use when synchronizing (default: {MOONSTREAM_CRAWL_WORKERS})."
             " If you set to 1, the main process handles synchronization without spawning subprocesses."
-        )
+        ),
     )
     parser_ethcrawler_blocks_sync.set_defaults(func=ethcrawler_blocks_sync_handler)
 

--- a/crawlers/moonstreamcrawlers/cli.py
+++ b/crawlers/moonstreamcrawlers/cli.py
@@ -103,6 +103,7 @@ def ethcrawler_blocks_sync_handler(args: argparse.Namespace) -> None:
             crawl_blocks_executor(
                 block_numbers_list=blocks_numbers_list,
                 with_transactions=bool(strtobool(args.transactions)),
+                num_processes=args.jobs,
             )
 
         print(f"Synchronized blocks from {bottom_block_number} to {top_block_number}")
@@ -224,6 +225,16 @@ def main() -> None:
         type=processing_order,
         default=ProcessingOrder.DESCENDING,
         help="Order in which to process blocks (choices: desc, asc; default: desc)",
+    )
+    parser_ethcrawler_blocks_sync.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=MOONSTREAM_CRAWL_WORKERS,
+        help=(
+            f"Number of processes to use when synchronizing (default: {MOONSTREAM_CRAWL_WORKERS})."
+            " If you set to 1, the main process handles synchronization without spawning subprocesses."
+        )
     )
     parser_ethcrawler_blocks_sync.set_defaults(func=ethcrawler_blocks_sync_handler)
 

--- a/crawlers/moonstreamcrawlers/test_cli.py
+++ b/crawlers/moonstreamcrawlers/test_cli.py
@@ -1,0 +1,117 @@
+import unittest
+
+from . import cli
+
+
+class TestYieldBlockNumbersLists(unittest.TestCase):
+    def test_yield_descending_10_6_step_4(self):
+        partition = [
+            block_numbers_list
+            for block_numbers_list in cli.yield_blocks_numbers_lists(
+                "10-6", block_step=4
+            )
+        ]
+        self.assertListEqual(partition, [[10, 9, 8, 7], [6]])
+
+    def test_yield_descending_10_6_step_3(self):
+        partition = [
+            block_numbers_list
+            for block_numbers_list in cli.yield_blocks_numbers_lists(
+                "10-6", block_step=3
+            )
+        ]
+        self.assertListEqual(partition, [[10, 9, 8], [7, 6]])
+
+    def test_yield_descending_10_6_descending_step_3(self):
+        partition = [
+            block_numbers_list
+            for block_numbers_list in cli.yield_blocks_numbers_lists(
+                "10-6", cli.ProcessingOrder.DESCENDING, 3
+            )
+        ]
+        self.assertListEqual(partition, [[10, 9, 8], [7, 6]])
+
+    def test_yield_descending_10_6_descending_step_10(self):
+        partition = [
+            block_numbers_list
+            for block_numbers_list in cli.yield_blocks_numbers_lists(
+                "10-6", cli.ProcessingOrder.DESCENDING, 10
+            )
+        ]
+        self.assertListEqual(partition, [[10, 9, 8, 7, 6]])
+
+    def test_yield_descending_6_10_step_4(self):
+        partition = [
+            block_numbers_list
+            for block_numbers_list in cli.yield_blocks_numbers_lists(
+                "6-10", block_step=4
+            )
+        ]
+        self.assertListEqual(partition, [[10, 9, 8, 7], [6]])
+
+    def test_yield_descending_6_10_step_3(self):
+        partition = [
+            block_numbers_list
+            for block_numbers_list in cli.yield_blocks_numbers_lists(
+                "6-10", block_step=3
+            )
+        ]
+        self.assertListEqual(partition, [[10, 9, 8], [7, 6]])
+
+    def test_yield_descending_6_10_descending_step_3(self):
+        partition = [
+            block_numbers_list
+            for block_numbers_list in cli.yield_blocks_numbers_lists(
+                "6-10", cli.ProcessingOrder.DESCENDING, 3
+            )
+        ]
+        self.assertListEqual(partition, [[10, 9, 8], [7, 6]])
+
+    def test_yield_descending_6_10_descending_step_10(self):
+        partition = [
+            block_numbers_list
+            for block_numbers_list in cli.yield_blocks_numbers_lists(
+                "6-10", cli.ProcessingOrder.DESCENDING, 10
+            )
+        ]
+        self.assertListEqual(partition, [[10, 9, 8, 7, 6]])
+
+    def test_yield_ascending_10_6_ascending_step_3(self):
+        partition = [
+            block_numbers_list
+            for block_numbers_list in cli.yield_blocks_numbers_lists(
+                "10-6", cli.ProcessingOrder.ASCENDING, 3
+            )
+        ]
+        self.assertListEqual(partition, [[6, 7, 8], [9, 10]])
+
+    def test_yield_ascending_10_6_ascending_step_10(self):
+        partition = [
+            block_numbers_list
+            for block_numbers_list in cli.yield_blocks_numbers_lists(
+                "10-6", cli.ProcessingOrder.ASCENDING, 10
+            )
+        ]
+        self.assertListEqual(partition, [[6, 7, 8, 9, 10]])
+
+    def test_yield_ascending_6_10_ascending_step_4(self):
+        partition = [
+            block_numbers_list
+            for block_numbers_list in cli.yield_blocks_numbers_lists(
+                "6-10", cli.ProcessingOrder.ASCENDING, 4
+            )
+        ]
+        self.assertListEqual(partition, [[6, 7, 8, 9], [10]])
+
+    def test_yield_ascending_6_10_ascending_step_10(self):
+        partition = [
+            block_numbers_list
+            for block_numbers_list in cli.yield_blocks_numbers_lists(
+                "6-10", cli.ProcessingOrder.ASCENDING, 10
+            )
+        ]
+        self.assertListEqual(partition, [[6, 7, 8, 9, 10]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

`--order {asc|desc}` with default `desc`
`--jobs` overrides `MOONSTREAM_CRAWL_WORKERS` environment variable from command line.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

Test manually. @kompotkot and I ran these commands on Pi.

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
