### PR TITLE
Systemd service and timer definition for "ethcrawler trending" crawl

### DIFF
--- a/crawlers/deploy/ethereum-trending.service
+++ b/crawlers/deploy/ethereum-trending.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Load trending Ethereum addresses to the database
+After=network.target
+
+[Service]
+Type=oneshot
+User=ubuntu
+Group=www-data
+WorkingDirectory=/home/ubuntu/moonstream/crawlers
+EnvironmentFile=/home/ubuntu/mooncrawl-secrets/app.env
+ExecStart=/usr/bin/bash -c '/home/ubuntu/mooncrawl-env/bin/python -m mooncrawl.ethcrawler trending -s $(date -u -d '-2 hours' +%Y%m%d-%H%MT%z) -e $(date -u +%Y%m%d-%H%MT%z)'

--- a/crawlers/deploy/ethereum-trending.service
+++ b/crawlers/deploy/ethereum-trending.service
@@ -8,4 +8,4 @@ User=ubuntu
 Group=www-data
 WorkingDirectory=/home/ubuntu/moonstream/crawlers
 EnvironmentFile=/home/ubuntu/mooncrawl-secrets/app.env
-ExecStart=/usr/bin/bash -c '/home/ubuntu/mooncrawl-env/bin/python -m mooncrawl.ethcrawler trending -s $(date -u -d '-2 hours' +%Y%m%d-%H%MT%z) -e $(date -u +%Y%m%d-%H%MT%z)'
+ExecStart=/usr/bin/bash -c '/home/ubuntu/mooncrawl-env/bin/python -m mooncrawl.ethcrawler trending'

--- a/crawlers/deploy/ethereum-trending.timer
+++ b/crawlers/deploy/ethereum-trending.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Load trending Ethereum addresses to the database every 5 minutes
+
+[Timer]
+OnBootSec=10s
+OnUnitActiveSec=5m
+
+[Install]
+WantedBy=timers.target

--- a/crawlers/mooncrawl/ethcrawler.py
+++ b/crawlers/mooncrawl/ethcrawler.py
@@ -4,6 +4,7 @@ Moonstream crawlers CLI.
 import argparse
 from enum import Enum
 import json
+import os
 import sys
 import time
 from typing import Iterator, List
@@ -177,7 +178,10 @@ def ethcrawler_trending_handler(args: argparse.Namespace) -> None:
         include_end=args.include_end,
     )
     results = trending(date_range)
-    if args.humbug:
+    humbug_token = args.humbug
+    if humbug_token is None:
+        humbug_token = os.environ.get("MOONSTREAM_HUMBUG_TOKEN")
+    if humbug_token:
         opening_bracket = "[" if args.include_start else "("
         closing_bracket = "]" if args.include_end else ")"
         title = f"Ethereum trending addresses: {opening_bracket}{args.start}, {args.end}{closing_bracket}"
@@ -358,7 +362,11 @@ def main() -> None:
     parser_ethcrawler_trending.add_argument(
         "--humbug",
         default=None,
-        help="If you would like to write this data to a Moonstream journal, please provide a Humbug token for that here.",
+        help=(
+            "If you would like to write this data to a Moonstream journal, please provide a Humbug "
+            "token for that here. (This argument overrides any value set in the "
+            "MOONSTREAM_HUMBUG_TOKEN environment variable)"
+        ),
     )
     parser_ethcrawler_trending.add_argument(
         "-o",

--- a/crawlers/mooncrawl/ethcrawler.py
+++ b/crawlers/mooncrawl/ethcrawler.py
@@ -2,6 +2,7 @@
 Moonstream crawlers CLI.
 """
 import argparse
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 import json
 import os
@@ -185,7 +186,7 @@ def ethcrawler_trending_handler(args: argparse.Namespace) -> None:
         opening_bracket = "[" if args.include_start else "("
         closing_bracket = "]" if args.include_end else ")"
         title = f"Ethereum trending addresses: {opening_bracket}{args.start}, {args.end}{closing_bracket}"
-        publish_json("ethereum_trending", args.humbug, title, results)
+        publish_json("ethereum_trending", humbug_token, title, results)
     with args.outfile as ofp:
         json.dump(results, ofp)
 
@@ -194,6 +195,8 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Moonstream crawlers CLI")
     parser.set_defaults(func=lambda _: parser.print_help())
     subcommands = parser.add_subparsers(description="Crawlers commands")
+
+    time_now = datetime.now(timezone.utc)
 
     # Ethereum blocks parser
     parser_ethcrawler_blocks = subcommands.add_parser(
@@ -339,8 +342,8 @@ def main() -> None:
         "-s",
         "--start",
         type=dateutil.parser.parse,
-        required=True,
-        help="Start time for window to calculate trending addresses in",
+        default=(time_now - timedelta(hours=1, minutes=0)).isoformat(),
+        help=f"Start time for window to calculate trending addresses in (default: {(time_now - timedelta(hours=1,minutes=0)).isoformat()})",
     )
     parser_ethcrawler_trending.add_argument(
         "--include-start",
@@ -351,8 +354,8 @@ def main() -> None:
         "-e",
         "--end",
         type=dateutil.parser.parse,
-        required=True,
-        help="End time for window to calculate trending addresses in",
+        default=time_now.isoformat(),
+        help=f"End time for window to calculate trending addresses in (default: {time_now.isoformat()})",
     )
     parser_ethcrawler_trending.add_argument(
         "--include-end",

--- a/crawlers/mooncrawl/ethcrawler.py
+++ b/crawlers/mooncrawl/ethcrawler.py
@@ -23,6 +23,7 @@ from .ethereum import (
 )
 from .publish import publish_json
 from .settings import MOONSTREAM_CRAWL_WORKERS
+from .version import MOONCRAWL_VERSION
 
 
 class ProcessingOrder(Enum):
@@ -186,7 +187,13 @@ def ethcrawler_trending_handler(args: argparse.Namespace) -> None:
         opening_bracket = "[" if args.include_start else "("
         closing_bracket = "]" if args.include_end else ")"
         title = f"Ethereum trending addresses: {opening_bracket}{args.start}, {args.end}{closing_bracket}"
-        publish_json("ethereum_trending", humbug_token, title, results)
+        publish_json(
+            "ethereum_trending",
+            humbug_token,
+            title,
+            results,
+            tags=[f"crawler_version:{MOONCRAWL_VERSION}"],
+        )
     with args.outfile as ofp:
         json.dump(results, ofp)
 

--- a/crawlers/mooncrawl/ethereum.py
+++ b/crawlers/mooncrawl/ethereum.py
@@ -317,7 +317,14 @@ def trending(
 
         return query
 
-    results: Dict[str, Any] = {}
+    results: Dict[str, Any] = {
+        "date_range": {
+            "start_time": date_range.start_time.isoformat(),
+            "end_time": date_range.end_time.isoformat(),
+            "include_start": date_range.include_start,
+            "include_end": date_range.include_end,
+        }
+    }
 
     try:
         transactions_out_query = make_query(


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

This PR adds a systemd service and timer for the trending ethereum addresses crawl.

It also modifies the `ethcrawler trending` CLI a bit to make it easier to invoke as a systemd unit (mostly involving putting sane defaults).

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

Run manually

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues
https://github.com/bugout-dev/moonstream/issues/83
<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
