### PR TITLE
Team page: fix side image gets too big

### DIFF
--- a/frontend/pages/team/index.js
+++ b/frontend/pages/team/index.js
@@ -155,7 +155,6 @@ const Product = () => {
           </Box>
           <Box
             w="full"
-            h="full"
             py={48}
             backgroundImage={`url(${assets[`team`]})`}
             backgroundSize="cover"


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes
- Hero image on team page was scaling wrong on `safari`

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

localhost `safari` `chrome`
<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
