### PR TITLE
HOME path missing when building with go deployment script

### DIFF
--- a/db/deploy/deploy.bash
+++ b/db/deploy/deploy.bash
@@ -13,7 +13,7 @@ set -eu
 echo
 echo
 echo "Building executable database server script with Go"
-/usr/local/go/bin/go build -o "${APP_DB_SERVER_DIR}/moonstreamdb" "${APP_DB_SERVER_DIR}/main.go"
+HOME=/root /usr/local/go/bin/go build -o "${APP_DB_SERVER_DIR}/moonstreamdb" "${APP_DB_SERVER_DIR}/main.go"
 
 echo
 echo


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

When instance execute startup script it missing $HOME variable and because of it also missing $GOPATH.

## How to test these changes?

Tested

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
