### PR TITLE
Fixed typo in deploy bash for polygon node

### DIFF
--- a/nodes/deploy/polygon/deploy.bash
+++ b/nodes/deploy/polygon/deploy.bash
@@ -18,7 +18,7 @@ SECRETS_DIR="${SECRETS_DIR:-/home/ubuntu/moonstream-secrets}"
 NODE_PARAMETERS_ENV_PATH="${SECRETS_DIR}/node.env"
 SCRIPT_DIR="$(realpath $(dirname $0))"
 BLOCKCHAIN="polygon"
-HEIMDALL_HOME="/mnt/disks/nodes/${BLOCKCHAIN}"
+HEIMDALL_HOME="/mnt/disks/nodes/${BLOCKCHAIN}/.heimdalld"
 
 set -eu
 


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Typo in `deploy.bash`

## How to test these changes?

Already in prod

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
