### PR TITLE
Add load older events in second request.

### DIFF
--- a/backend/moonstream/settings.py
+++ b/backend/moonstream/settings.py
@@ -58,7 +58,7 @@ MOONSTREAM_ETHEREUM_WEB3_PROVIDER_URI = os.environ.get(
     "MOONSTREAM_ETHEREUM_WEB3_PROVIDER_URI", ""
 )
 if MOONSTREAM_ETHEREUM_WEB3_PROVIDER_URI == "":
-    raise ValueError("MOONSTREAM_WEB3_PROVIDER_URI environment variable must be set")
+    raise ValueError("MOONSTREAM_ETHEREUM_WEB3_PROVIDER_URI environment variable must be set")
 MOONSTREAM_NODE_ETHEREUM_IPC_PORT = os.environ.get(
     "MOONSTREAM_NODE_ETHEREUM_IPC_PORT", 8545
 )

--- a/backend/moonstream/settings.py
+++ b/backend/moonstream/settings.py
@@ -58,7 +58,9 @@ MOONSTREAM_ETHEREUM_WEB3_PROVIDER_URI = os.environ.get(
     "MOONSTREAM_ETHEREUM_WEB3_PROVIDER_URI", ""
 )
 if MOONSTREAM_ETHEREUM_WEB3_PROVIDER_URI == "":
-    raise ValueError("MOONSTREAM_ETHEREUM_WEB3_PROVIDER_URI environment variable must be set")
+    raise ValueError(
+        "MOONSTREAM_ETHEREUM_WEB3_PROVIDER_URI environment variable must be set"
+    )
 MOONSTREAM_NODE_ETHEREUM_IPC_PORT = os.environ.get(
     "MOONSTREAM_NODE_ETHEREUM_IPC_PORT", 8545
 )

--- a/frontend/src/components/EntriesNavigation.js
+++ b/frontend/src/components/EntriesNavigation.js
@@ -60,6 +60,7 @@ const EntriesNavigation = () => {
   const { cursor, setCursor, streamCache, setStreamCache } =
     useContext(DataContext);
   const ui = useContext(UIContext);
+  const [firstLoading, setFirstLoading] = useState(true);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { subscriptionsCache } = useSubscriptions();
   const [initialized, setInitialized] = useState(false);
@@ -87,6 +88,7 @@ const EntriesNavigation = () => {
     loadNewerEventsIsFetching,
     previousEventIsFetching,
     nextEventIsFetching,
+    olderEvent,
   } = useStream(
     ui.searchTerm.q,
     streamCache,
@@ -104,6 +106,13 @@ const EntriesNavigation = () => {
       nextEventRefetch();
       previousEventRefetch();
       setInitialized(true);
+    } else if (
+      streamCache.length == 0 &&
+      olderEvent?.event_timestamp &&
+      firstLoading
+    ) {
+      loadPreviousEventHandler();
+      setFirstLoading(false);
     }
   }, [
     streamBoundary,

--- a/frontend/src/core/hooks/useStream.js
+++ b/frontend/src/core/hooks/useStream.js
@@ -367,6 +367,7 @@ const useStream = (q, streamCache, setStreamCache, cursor, setCursor) => {
     loadNewerEventsIsFetching,
     loadPreviousEventHandler,
     loadNewesEventHandler,
+    olderEvent,
   };
 };
 export default useStream;


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Add adition state to use effect on EntriesNavigator wich wait state when cache still empty list but we get `olderEvent.event_timestamp` have flag wich protect from execution that if state again maybe unrequired need check later.
Fix `settings.py` variable must be set error.


<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
