### PR TITLE
solve circular redirects

### DIFF
--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -24,6 +24,16 @@ export default function CachingApp({ Component, pageProps }) {
   const router = useRouter();
 
   useEffect(() => {
+    if (
+      router.pathname !== "/entry-point" &&
+      window &&
+      localStorage.getItem("entry_point")
+    ) {
+      localStorage.removeItem("entry_point");
+    }
+  }, [router]);
+
+  useEffect(() => {
     const handleStart = () => {
       NProgress.start();
     };

--- a/frontend/pages/entry-point.js
+++ b/frontend/pages/entry-point.js
@@ -1,0 +1,29 @@
+import { useRouter } from "next/router";
+import { useContext, useLayoutEffect } from "react";
+
+import UserContext from "../src/core/providers/UserProvider/context";
+import { getLayout } from "../src/layouts/EntryPointLayout";
+
+const EntryPoint = () => {
+  const router = useRouter();
+  const { isInit } = useContext(UserContext);
+
+  useLayoutEffect(() => {
+    if (router.isReady && isInit && router.asPath !== router.pathname + `/`) {
+      if (localStorage.getItem("entry_point")) {
+        router.replace("/404", router.asPath);
+      } else {
+        localStorage.setItem("entry_point", 1);
+        router.replace(router.asPath, undefined, {
+          shallow: true,
+        });
+      }
+    }
+  }, [router, isInit]);
+
+  return "";
+};
+
+EntryPoint.getLayout = getLayout;
+
+export default EntryPoint;

--- a/frontend/src/layouts/EntryPointLayout.js
+++ b/frontend/src/layouts/EntryPointLayout.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+const EntryPointLayout = (props) => {
+  return props.children;
+};
+
+export const getLayout = (page) => <EntryPointLayout>{page}</EntryPointLayout>;
+
+export default EntryPointLayout;


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Entry point for AWS now is `/entry-point/index.html` 
When redirected to, useEffect will store flag in local storage and 
`_app` will delete it after any other than `/entry-point` page is loaded

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

Deploy, Try to go to correct way - it should work. 
Try to go to nonexisting route - it should redirect to `404` page 


<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

finally resolves #60 

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
