### PR TITLE
better image sizing on SplitWithImage components

### DIFF
--- a/frontend/src/components/SplitWithImage.js
+++ b/frontend/src/components/SplitWithImage.js
@@ -122,6 +122,7 @@ const SplitWithImage = ({
               src={imgURL}
               objectFit={"contain"}
               boxShadow={imgBoxShadow ?? "inherit"}
+              height="auto"
             />
           </Flex>
         )}
@@ -212,7 +213,7 @@ const SplitWithImage = ({
               alt={"feature image"}
               src={imgURL}
               objectFit={"contain"}
-              h="fit-content"
+              h="auto"
               boxShadow={imgBoxShadow ?? "inherit"}
             />
           </Flex>


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

On mobile phone images of `<SplitWithImage />` scaled wrongly, fixed that

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
