### PR TITLE
Improved speed of getting latest event with sorted()

### DIFF
--- a/backend/.isort.cfg
+++ b/backend/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+profile = black
+multi_line_output = 3

--- a/backend/moonstreamapi/providers/ethereum_blockchain.py
+++ b/backend/moonstreamapi/providers/ethereum_blockchain.py
@@ -346,6 +346,7 @@ def latest_events(
 
     # Instruction order_by makes sql query speed unacceptable,
     # so it was replaced to sorted() function.
+    # TODO(kompotkot): Revert back work with order_by when database will be optimized
     ethereum_transactions = query_ethereum_transactions(
         db_session, stream_boundary, parsed_filters
     )

--- a/backend/moonstreamapi/version.py
+++ b/backend/moonstreamapi/version.py
@@ -2,4 +2,4 @@
 Moonstream library and API version.
 """
 
-MOONSTREAMAPI_VERSION = "0.1.0"
+MOONSTREAMAPI_VERSION = "0.1.1"


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Instruction order_by makes sql query speed unacceptable, so it was replaced to sorted() function.

## How to test these changes?

Tested locally

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
