### PR TITLE
fix query keys to be correct to stop refetches

### DIFF
--- a/frontend/pages/dashboard/[dashboardId].js
+++ b/frontend/pages/dashboard/[dashboardId].js
@@ -216,8 +216,7 @@ const Analytics = () => {
                 <SubscriptionReport
                   timeRange={timeRange}
                   url={s3PresignedURLs[timeRange]}
-                  id={v4()}
-                  type={v4()}
+                  id={dashboardId}
                   refetchLinks={dashboardLinksCache.refetch}
                 />
               </Flex>

--- a/frontend/src/components/SubscriptionReport.js
+++ b/frontend/src/components/SubscriptionReport.js
@@ -12,12 +12,12 @@ timeMap[HOUR_KEY] = "hour";
 timeMap[DAY_KEY] = "day";
 timeMap[WEEK_KEY] = "week";
 
-const SubscriptionReport = ({ timeRange, url, id, type, refetchLinks }) => {
+const SubscriptionReport = ({ timeRange, url, id, refetchLinks }) => {
   const { data, isLoading } = usePresignedURL({
     url: url,
     isEnabled: true,
     id: id,
-    type: type,
+    cacheType: timeRange,
     requestNewURLCallback: refetchLinks,
   });
   const plotMinW = "250px";


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Query keys were defined as randomly generated uuids, i changed those to be `dashboardId` and `timeRange`
This should make query key correspond to time range and dashboard as it should be. 

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

Run and test that s3 objects is being pulled only once 

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues
resolve https://github.com/bugout-dev/moonstream/issues/464

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
