### PR TITLE
Force moonstreamdb>=0.2.2 to fix Moonstream API failures

### DIFF
--- a/backend/setup.py
+++ b/backend/setup.py
@@ -15,7 +15,7 @@ setup(
         "boto3",
         "bugout",
         "fastapi",
-        "moonstreamdb",
+        "moonstreamdb>=0.2.2",
         "humbug",
         "pydantic",
         "pyevmasm",


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Force `moonstreamdb>=0.2.2` in backend `setup.py`.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
