### PR TITLE
Continuous crawler batch saving

### DIFF
--- a/crawlers/mooncrawl/mooncrawl/moonworm_crawler/cli.py
+++ b/crawlers/mooncrawl/mooncrawl/moonworm_crawler/cli.py
@@ -167,7 +167,7 @@ def main() -> None:
         "--confirmations",
         "-c",
         type=int,
-        default=100,
+        default=175,
         help="Number of confirmations to wait for",
     )
 

--- a/crawlers/mooncrawl/mooncrawl/moonworm_crawler/crawler.py
+++ b/crawlers/mooncrawl/mooncrawl/moonworm_crawler/crawler.py
@@ -332,7 +332,7 @@ def heartbeat(
         token=MOONSTREAM_ADMIN_ACCESS_TOKEN,
         journal_id=MOONSTREAM_MOONWORM_TASKS_JOURNAL,
         entry_id=heartbeat_entry_id,
-        title=f"{crawler_type} Heartbeat - {blockchain_type.value}",
+        title=f"{crawler_type} Heartbeat - {blockchain_type.value}. Status: {crawler_status['status']} - {crawler_status['current_time']}",
         content=f"{json.dumps(crawler_status, indent=2)}",
     )
     if is_dead:

--- a/crawlers/mooncrawl/mooncrawl/moonworm_crawler/db.py
+++ b/crawlers/mooncrawl/mooncrawl/moonworm_crawler/db.py
@@ -87,12 +87,12 @@ def get_last_labeled_block_number(
     return block_number[0] if block_number else None
 
 
-def save_labels(db_session: Session, labels: List[Base]) -> None:
+def commit_session(db_session: Session) -> None:
     """
     Save labels in the database.
     """
     try:
-        db_session.add_all(labels)
+        logger.info("Committing session to database")
         db_session.commit()
     except Exception as e:
         logger.error(f"Failed to save labels: {e}")
@@ -100,7 +100,7 @@ def save_labels(db_session: Session, labels: List[Base]) -> None:
         raise e
 
 
-def save_events(
+def add_events_to_session(
     db_session: Session, events: List[Event], blockchain_type: AvailableBlockchainType
 ) -> None:
     label_model = get_label_model(blockchain_type)
@@ -134,10 +134,11 @@ def save_events(
         ):
             labels_to_save.append(_event_to_label(blockchain_type, event))
 
-    save_labels(db_session, labels_to_save)
+    logger.info(f"Saving {len(labels_to_save)} labels to session")
+    db_session.add_all(labels_to_save)
 
 
-def save_function_calls(
+def add_function_calls_to_session(
     db_session: Session,
     function_calls: List[ContractFunctionCall],
     blockchain_type: AvailableBlockchainType,
@@ -166,4 +167,5 @@ def save_function_calls(
         if function_call.transaction_hash not in existing_labels_transactions
     ]
 
-    save_labels(db_session, labels_to_save)
+    logger.info(f"Saving {len(labels_to_save)} labels to session")
+    db_session.add_all(labels_to_save)

--- a/crawlers/mooncrawl/mooncrawl/version.py
+++ b/crawlers/mooncrawl/mooncrawl/version.py
@@ -2,4 +2,4 @@
 Moonstream crawlers version.
 """
 
-MOONCRAWL_VERSION = "0.1.2"
+MOONCRAWL_VERSION = "0.1.3"

--- a/crawlers/mooncrawl/setup.py
+++ b/crawlers/mooncrawl/setup.py
@@ -38,7 +38,7 @@ setup(
         "chardet",
         "fastapi",
         "moonstreamdb>=0.2.2",
-        "moonworm>=0.1.7",
+        "moonworm==0.1.11",
         "humbug",
         "pydantic",
         "python-dateutil",


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes
1. Crawler now will save labels once in `heartbeat_interval` (default 1 min)
2. Confirmations count increased to 175, so `moonworm-crawler` will be slower that blocks crawler and can use db more frequently 
<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
