### PR TITLE
There is no need of data key at tx

### DIFF
--- a/crawlers/mooncrawl/mooncrawl/blockchain.py
+++ b/crawlers/mooncrawl/mooncrawl/blockchain.py
@@ -211,8 +211,6 @@ def add_block_transactions(
             transaction_type=int(tx["type"], 0) if tx["type"] is not None else None,
             value=tx.value,
         )
-        if blockchain_type == AvailableBlockchainType.XDAI:
-            tx_obj.data = tx.data
 
         db_session.add(tx_obj)
 

--- a/crawlers/mooncrawl/mooncrawl/version.py
+++ b/crawlers/mooncrawl/mooncrawl/version.py
@@ -2,4 +2,4 @@
 Moonstream crawlers version.
 """
 
-MOONCRAWL_VERSION = "0.1.6"
+MOONCRAWL_VERSION = "0.1.7"


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Request:

```
--data-raw '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x161cb42", true],"id":1}'
```

Response from XDai node running as Nethermind client locally, access via json rpc:

```bash
{
                "hash": "0x377b4d02f5d655a3747c28c4ba1585b94ac32ff04e834b87eed389946bac1d5d",
                "data": "0x74759ae40000000000000000000000000000000000000000000000000000000000000f130000000000000000000000000000000000000000000000000000000000000f130000000000000000000000000000000000000000000000000000000002f572400000000000000000000000000000000000000000000000000000000000000f13",
                "input": "0x74759ae40000000000000000000000000000000000000000000000000000000000000f130000000000000000000000000000000000000000000000000000000000000f130000000000000000000000000000000000000000000000000000000002f572400000000000000000000000000000000000000000000000000000000000000f13",
            }
```

As we can see here a duplication in `data` and `input` key.

## How to test these changes?

Tested locally

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
