### PR TITLE
Add x-node-url response header to requests

### DIFF
--- a/nodes/node_balancer/README.md
+++ b/nodes/node_balancer/README.md
@@ -1,17 +1,47 @@
 # Node Balancer application
 
-# Installation
+## Installation and configuration
 
--   Prepare environment variables
+-   Prepare environment variables, according with `sample.env`.
 -   Build application
 
 ```bash
 go build -o nodebalancer .
 ```
 
-# Work with nodebalancer
+-   Generate configuration
 
-## add-access
+```bash
+nodebalancer generate-config
+```
+
+-   Modify configuration. Tags should NOT repeat blockchain, as it is specified in `blockchain` key. Example of configuration:
+
+```bash
+[
+  {
+    "blockchain": "ethereum",
+    "endpoint": "http://127.0.0.1:8545",
+	"tags": ["local"]
+  },
+  {
+    "blockchain": "ethereum",
+    "endpoint": "http://127.0.0.1:9585",
+	"tags": ["local"]
+  },
+  {
+	"blockchain": "ethereum",
+    "endpoint": "https://cool-name.quiknode.pro/y0urn0de1den1f1cat0r/",
+	"tags": ["external"]
+  }
+]
+```
+
+So if with request will be specified tag `local` will be returned node with corresponding tag.
+
+## Work with nodebalancer
+
+### add-access
 
 Add new access for user:
 
@@ -25,7 +55,7 @@ nodebalancer add-access \
 	--blockchain--access true
 ```
 
-## delete-access
+### delete-access
 
 Delete user access:
 
@@ -37,7 +67,7 @@ nodebalancer delete-access \
 
 If `access-id` not specified, all user accesses will be deleted.
 
-## users
+### users
 
 ```bash
 nodebalancer users | jq .
@@ -67,7 +97,7 @@ This command will return a list of bugout resources of registered users to acces
 
 `extended_methods` - boolean which allow you to call not whitelisted method to blockchain node, by default for new user this is equal to `false`
 
-## server
+### server
 
 ```bash
 nodebalancer server -host 0.0.0.0 -port 8544 -healthcheck
@@ -76,17 +106,17 @@ nodebalancer server -host 0.0.0.0 -port 8544 -healthcheck
 Flag `--healthcheck` will execute background process to ping-pong available nodes to keep their status and current block number.
 Flag `--debug` will extend output of each request to server and healthchecks summary.
 
-# Work with node
+## Work with node
 
 Common request to fetch block number
 
 ```bash
-curl --request GET 'http://127.0.0.1:8544/nb/ethereum/jsonrpc?access_id=<access_id>&data_source=<blockchain/database>' \
+curl --request POST 'http://127.0.0.1:8544/nb/ethereum/jsonrpc?access_id=<access_id>&data_source=<blockchain/database>' \
     --header 'Content-Type: application/json' \
     --data-raw '{
         "jsonrpc":"2.0",
         "method":"eth_getBlockByNumber",
-        "params":["0xb71b64", false],
+        "params":["latest", false],
         "id":1
     }'
 ```

--- a/nodes/node_balancer/cmd/nodebalancer/balancer.go
+++ b/nodes/node_balancer/cmd/nodebalancer/balancer.go
@@ -105,27 +105,7 @@ func (node *Node) UpdateNodeState(currentBlock uint64, alive bool) (callCounter 
 	return callCounter
 }
 
-// IncreaseCallCounter increased to 1 each time node called
-func (node *Node) IncreaseCallCounter() {
-	node.mux.Lock()
-	if node.CallCounter >= NB_MAX_COUNTER_NUMBER {
-		log.Printf("Number of calls for node %s reached %d limit, reset the counter.", node.Endpoint, NB_MAX_COUNTER_NUMBER)
-		node.CallCounter = uint64(0)
-	} else {
-		node.CallCounter++
-	}
-	node.mux.Unlock()
-}
-
-func containsGeneric[T comparable](b []T, e T) bool {
-	for _, v := range b {
-		if v == e {
-			return true
-		}
-	}
-	return false
-}
-
+// FilterTagsNodes returns nodes with provided tags
 func (npool *NodePool) FilterTagsNodes(tags []string) ([]*Node, TopNodeBlock) {
 	nodesMap := npool.NodesMap
 	nodesSet := npool.NodesSet
@@ -174,7 +154,7 @@ func GetNextNode(nodes []*Node, topNode TopNodeBlock) *Node {
 		if node.IsAlive() {
 			currentBlock := node.CurrentBlock
 			if currentBlock < topNode.Block-NB_HIGHEST_BLOCK_SHIFT {
-				// Bypass outdated nodes
+				// Bypass too outdated nodes
 				continue
 			}
 			if node.CallCounter < nextNode.CallCounter {
@@ -183,12 +163,10 @@ func GetNextNode(nodes []*Node, topNode TopNodeBlock) *Node {
 		}
 	}
 
-	if nextNode == nil {
-		return nil
+	if nextNode != nil {
+		// Increase CallCounter value with 1
+		atomic.AddUint64(&nextNode.CallCounter, uint64(1))
 	}
-
-	// Increase CallCounter value with 1
-	atomic.AddUint64(&nextNode.CallCounter, uint64(1))
 
 	return nextNode
 }
@@ -221,41 +199,41 @@ func StatusLog() {
 // HealthCheck fetch the node latest block
 func HealthCheck() {
 	for blockchain, nodes := range blockchainPools {
-		for _, n := range nodes.NodesSet {
+		for _, node := range nodes.NodesSet {
 			alive := false
 
 			httpClient := http.Client{Timeout: NB_HEALTH_CHECK_CALL_TIMEOUT}
 			resp, err := httpClient.Post(
-				n.Endpoint.String(),
+				node.Endpoint.String(),
 				"application/json",
 				bytes.NewBuffer([]byte(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", false],"id":1}`)),
 			)
 			if err != nil {
-				n.UpdateNodeState(0, alive)
-				log.Printf("Unable to reach node: %s", n.Endpoint.Host)
+				node.UpdateNodeState(0, alive)
+				log.Printf("Unable to reach node: %s", node.Endpoint.Host)
 				continue
 			}
 			defer resp.Body.Close()
 
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
-				n.UpdateNodeState(0, alive)
-				log.Printf("Unable to parse response from %s node, err %v", n.Endpoint.Host, err)
+				node.UpdateNodeState(0, alive)
+				log.Printf("Unable to parse response from %s node, err %v", node.Endpoint.Host, err)
 				continue
 			}
 
 			var statusResponse NodeStatusResponse
 			err = json.Unmarshal(body, &statusResponse)
 			if err != nil {
-				n.UpdateNodeState(0, alive)
-				log.Printf("Unable to read json response from %s node, err: %v", n.Endpoint.Host, err)
+				node.UpdateNodeState(0, alive)
+				log.Printf("Unable to read json response from %s node, err: %v", node.Endpoint.Host, err)
 				continue
 			}
 
 			blockNumberHex := strings.Replace(statusResponse.Result.Number, "0x", "", -1)
 			blockNumber, err := strconv.ParseUint(blockNumberHex, 16, 64)
 			if err != nil {
-				n.UpdateNodeState(0, alive)
+				node.UpdateNodeState(0, alive)
 				log.Printf("Unable to parse block number from hex to string, err: %v", err)
 				continue
 			}
@@ -264,15 +242,24 @@ func HealthCheck() {
 			if blockNumber != 0 {
 				alive = true
 			}
-			callCounter := n.UpdateNodeState(blockNumber, alive)
+			callCounter := node.UpdateNodeState(blockNumber, alive)
 
 			if blockNumber > nodes.TopNode.Block {
 				nodes.TopNode.Block = blockNumber
-				nodes.TopNode.Node = n
+				nodes.TopNode.Node = node
+			}
+
+			if node.CallCounter >= NB_MAX_COUNTER_NUMBER {
+				log.Printf(
+					"Number of CallCounter for node %s reached %d limit, reset the counter.",
+					node.Endpoint, NB_MAX_COUNTER_NUMBER,
+				)
+				atomic.StoreUint64(&node.CallCounter, uint64(0))
 			}
 
 			log.Printf(
-				"In blockchain %s node %s is alive: %t with current block: %d called: %d times", blockchain, n.Endpoint.Host, alive, blockNumber, callCounter,
+				"Blockchain %s node %s is alive: %t with current block: %d called: %d times",
+				blockchain, node.Endpoint.Host, alive, blockNumber, callCounter,
 			)
 		}
 	}

--- a/nodes/node_balancer/cmd/nodebalancer/cli.go
+++ b/nodes/node_balancer/cmd/nodebalancer/cli.go
@@ -167,7 +167,7 @@ func (s *StateCLI) populateCLI() {
 	// Common flag pointers
 	for _, fs := range []*flag.FlagSet{s.addAccessCmd, s.generateConfigCmd, s.deleteAccessCmd, s.serverCmd, s.usersCmd, s.versionCmd} {
 		fs.BoolVar(&s.helpFlag, "help", false, "Show help message")
-		fs.StringVar(&s.configPathFlag, "config", "", "Path to configuration file (default: ~/.nodebalancer/config.txt)")
+		fs.StringVar(&s.configPathFlag, "config", "", "Path to configuration file (default: ~/.nodebalancer/config.json)")
 	}
 
 	// Add, delete and list user access subcommand flag pointers

--- a/nodes/node_balancer/cmd/nodebalancer/configs.go
+++ b/nodes/node_balancer/cmd/nodebalancer/configs.go
@@ -34,7 +34,8 @@ var (
 	NB_MAX_COUNTER_NUMBER = uint64(10000000)
 
 	// Client configuration
-	NB_CLIENT_NODE_KEEP_ALIVE = int64(5) // How long to store node in hot list for client in seconds
+	NB_CLIENT_NODE_KEEP_ALIVE = int64(1)   // How long to store node in hot list for client in seconds
+	NB_HIGHEST_BLOCK_SHIFT    = uint64(50) // Allowed shift to prefer node with most highest block
 
 	NB_ACCESS_ID_HEADER   = os.Getenv("NB_ACCESS_ID_HEADER")
 	NB_DATA_SOURCE_HEADER = os.Getenv("NB_DATA_SOURCE_HEADER")

--- a/nodes/node_balancer/cmd/nodebalancer/configs.go
+++ b/nodes/node_balancer/cmd/nodebalancer/configs.go
@@ -34,7 +34,7 @@ var (
 	NB_MAX_COUNTER_NUMBER = uint64(10000000)
 
 	// Client configuration
-	NB_CLIENT_NODE_KEEP_ALIVE = int64(1)   // How long to store node in hot list for client in seconds
+	NB_CLIENT_NODE_KEEP_ALIVE = int64(5)   // How long to store node in hot list for client in seconds
 	NB_HIGHEST_BLOCK_SHIFT    = uint64(50) // Allowed shift to prefer node with most highest block
 
 	NB_ACCESS_ID_HEADER   = os.Getenv("NB_ACCESS_ID_HEADER")

--- a/nodes/node_balancer/cmd/nodebalancer/configs.go
+++ b/nodes/node_balancer/cmd/nodebalancer/configs.go
@@ -18,7 +18,6 @@ var (
 	nodeConfigs []NodeConfig
 
 	// Bugout and application configuration
-	BUGOUT_AUTH_URL          = os.Getenv("BUGOUT_AUTH_URL")
 	BUGOUT_AUTH_CALL_TIMEOUT = time.Second * 5
 	NB_APPLICATION_ID        = os.Getenv("NB_APPLICATION_ID")
 	NB_CONTROLLER_TOKEN      = os.Getenv("NB_CONTROLLER_TOKEN")
@@ -60,8 +59,9 @@ func CheckEnvVarSet() {
 
 // Nodes configuration
 type NodeConfig struct {
-	Blockchain string `json:"blockchain"`
-	Endpoint   string `json:"endpoint"`
+	Blockchain string   `json:"blockchain"`
+	Endpoint   string   `json:"endpoint"`
+	Tags       []string `json:"tags"`
 }
 
 func LoadConfig(configPath string) error {
@@ -108,7 +108,7 @@ func GetConfigPath(providedPath string) (*ConfigPlacement, error) {
 			return nil, fmt.Errorf("Unable to find user home directory, %v", err)
 		}
 		configDirPath = fmt.Sprintf("%s/.nodebalancer", homeDir)
-		configPath = fmt.Sprintf("%s/config.txt", configDirPath)
+		configPath = fmt.Sprintf("%s/config.json", configDirPath)
 	} else {
 		configPath = strings.TrimSuffix(providedPath, "/")
 		configDirPath = filepath.Dir(configPath)
@@ -144,7 +144,7 @@ func GenerateDefaultConfig(config *ConfigPlacement) error {
 
 	if !config.ConfigExists {
 		tempConfig := []NodeConfig{
-			{Blockchain: "ethereum", Endpoint: "http://127.0.0.1:8545"},
+			{Blockchain: "ethereum", Endpoint: "http://127.0.0.1:8545", Tags: []string{"local"}},
 		}
 		tempConfigJson, err := json.Marshal(tempConfig)
 		if err != nil {

--- a/nodes/node_balancer/cmd/nodebalancer/middleware.go
+++ b/nodes/node_balancer/cmd/nodebalancer/middleware.go
@@ -98,13 +98,13 @@ func (ac *AccessCache) Cleanup() (int64, int64) {
 	return removedAccessIds, totalAccessIds
 }
 
-func initCacheCleaning(debug bool) {
+func initCacheCleaning() {
 	t := time.NewTicker(NB_CACHE_CLEANING_INTERVAL)
 	for {
 		select {
 		case <-t.C:
 			removedAccessIds, totalAccessIds := accessIdCache.Cleanup()
-			if debug {
+			if stateCLI.enableDebugFlag {
 				log.Printf("Removed %d elements from access id cache", removedAccessIds)
 			}
 			log.Printf("Elements in access id cache: %d", totalAccessIds)

--- a/nodes/node_balancer/cmd/nodebalancer/routes.go
+++ b/nodes/node_balancer/cmd/nodebalancer/routes.go
@@ -56,8 +56,6 @@ func lbHandler(w http.ResponseWriter, r *http.Request) {
 	// Save origin path, to use in proxyErrorHandler if node will not response
 	r.Header.Add("X-Origin-Path", r.URL.Path)
 
-	w.Header().Add("X-Node-URL", node.Endpoint.String())
-
 	switch {
 	case strings.HasPrefix(r.URL.Path, fmt.Sprintf("/nb/%s/jsonrpc", blockchain)):
 		lbJSONRPCHandler(w, r, blockchain, currentClientAccess)
@@ -134,6 +132,7 @@ func lbJSONRPCHandler(w http.ResponseWriter, r *http.Request, blockchain string,
 
 		// Overwrite Path so response will be returned to correct place
 		r.URL.Path = "/"
+		w.Header().Add("X-Node-URL", node.Endpoint.String())
 		node.GethReverseProxy.ServeHTTP(w, r)
 		return
 	case currentClientAccess.dataSource == "database":

--- a/nodes/node_balancer/cmd/nodebalancer/routes.go
+++ b/nodes/node_balancer/cmd/nodebalancer/routes.go
@@ -130,8 +130,6 @@ func lbJSONRPCHandler(w http.ResponseWriter, r *http.Request, blockchain string,
 			}
 		}
 
-		node.IncreaseCallCounter()
-
 		// Overwrite Path so response will be returned to correct place
 		r.URL.Path = "/"
 		node.GethReverseProxy.ServeHTTP(w, r)

--- a/nodes/node_balancer/cmd/nodebalancer/server.go
+++ b/nodes/node_balancer/cmd/nodebalancer/server.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"context"
-	"encoding/json"
+	// "encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -130,32 +130,23 @@ func Server() {
 		os.Exit(1)
 	}
 	if len(resources.Resources) != 1 {
-		fmt.Printf("User with provided access identifier has wrong number of resources, err: %v\n", err)
-		os.Exit(1)
+		log.Println("There are no access IDs for users in resources")
+	} else {
+		log.Println("Found user access IDs in resources")
 	}
-	resource_data, err := json.Marshal(resources.Resources[0].ResourceData)
-	if err != nil {
-		fmt.Printf("Unable to encode resource data interface to json, err: %v\n", err)
-		os.Exit(1)
-	}
-	var clientAccess ClientResourceData
-	err = json.Unmarshal(resource_data, &clientAccess)
-	if err != nil {
-		fmt.Printf("Unable to decode resource data json to structure, err: %v\n", err)
-		os.Exit(1)
-	}
+
+	// Set internal crawlers access to bypass requests from internal services
+	// without fetching data from authn Brood server
+	internalCrawlersUserID := uuid.New().String()
 	internalCrawlersAccess = ClientResourceData{
-		UserID:           clientAccess.UserID,
-		AccessID:         clientAccess.AccessID,
-		Name:             clientAccess.Name,
-		Description:      clientAccess.Description,
-		BlockchainAccess: clientAccess.BlockchainAccess,
-		ExtendedMethods:  clientAccess.ExtendedMethods,
+		UserID:           internalCrawlersUserID,
+		AccessID:         NB_CONTROLLER_ACCESS_ID,
+		Name:             "InternalCrawlersAccess",
+		Description:      "Access for internal crawlers.",
+		BlockchainAccess: true,
+		ExtendedMethods:  true,
 	}
-	log.Printf(
-		"Internal crawlers access set, resource id: %s, blockchain access: %t, extended methods: %t",
-		resources.Resources[0].Id, clientAccess.BlockchainAccess, clientAccess.ExtendedMethods,
-	)
+	log.Printf("Internal crawlers access set with user ID: %s", internalCrawlersUserID)
 
 	err = InitDatabaseClient()
 	if err != nil {

--- a/nodes/node_balancer/cmd/nodebalancer/server.go
+++ b/nodes/node_balancer/cmd/nodebalancer/server.go
@@ -128,10 +128,11 @@ func Server() {
 		fmt.Printf("Unable to get user with provided access identifier, err: %v\n", err)
 		os.Exit(1)
 	}
+	resourcesLog := "Access with resources established."
 	if len(resources.Resources) != 1 {
-		log.Println("There are no access IDs for users in resources")
+		log.Printf("%s There are no access IDs for users in resources", resourcesLog)
 	} else {
-		log.Println("Found user access IDs in resources")
+		log.Printf("%s Found user access IDs in resources", resourcesLog)
 	}
 
 	// Set internal crawlers access to bypass requests from internal services
@@ -145,7 +146,6 @@ func Server() {
 		BlockchainAccess: true,
 		ExtendedMethods:  true,
 	}
-	log.Printf("Internal crawlers access set with user ID: %s", internalCrawlersUserID)
 
 	err = InitDatabaseClient()
 	if err != nil {
@@ -185,6 +185,8 @@ func Server() {
 			r.Header.Del(strings.Title(NB_DATA_SOURCE_HEADER))
 			// Change r.Host from nodebalancer's to end host so TLS check will be passed
 			r.Host = r.URL.Host
+			// Explicit set of r.URL requires, because by default it adds trailing slash and brake some urls
+			r.URL = endpoint
 		}
 		proxyErrorHandler(proxyToEndpoint, endpoint)
 

--- a/nodes/node_balancer/cmd/nodebalancer/version.go
+++ b/nodes/node_balancer/cmd/nodebalancer/version.go
@@ -1,3 +1,3 @@
 package main
 
-var NB_VERSION = "0.2.1"
+var NB_VERSION = "0.2.2"

--- a/nodes/node_balancer/go.mod
+++ b/nodes/node_balancer/go.mod
@@ -1,6 +1,6 @@
 module github.com/bugout-dev/moonstream/nodes/node_balancer
 
-go 1.17
+go 1.18
 
 require (
 	github.com/bugout-dev/bugout-go v0.3.4

--- a/nodes/node_balancer/go.mod
+++ b/nodes/node_balancer/go.mod
@@ -1,6 +1,6 @@
 module github.com/bugout-dev/moonstream/nodes/node_balancer
 
-go 1.18
+go 1.17
 
 require (
 	github.com/bugout-dev/bugout-go v0.3.4

--- a/nodes/node_balancer/sample.env
+++ b/nodes/node_balancer/sample.env
@@ -1,5 +1,5 @@
 # Required environment variables for load balancer
-export BUGOUT_AUTH_URL="https://auth.bugout.dev"
+export BUGOUT_BROOD_URL="https://auth.bugout.dev"
 export NB_APPLICATION_ID="<application_id_to_controll_access>"
 export NB_CONTROLLER_TOKEN="<token_of_controller_user>"
 export NB_CONTROLLER_ACCESS_ID="<controller_access_id_for_internal_crawlers>"


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

The `x-node-url` response header specifies which node a JSONRPC request served by a blockchain (not database) was served from.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

Tested locally with curl:

```
curl -v --request POST "http://127.0.0.1:8544/nb/polygon/jsonrpc?access_id=$NB_CONTROLLER_ACCESS_ID&data_source=blockchain" \
    --header 'Content-Type: application/json' \
    --data-raw '{
        "jsonrpc":"2.0",
        "method":"eth_blockNumber",
        "id":1
    }'
```

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
